### PR TITLE
issue #2 seem solved

### DIFF
--- a/domino.h
+++ b/domino.h
@@ -44,7 +44,7 @@ friend class Draw;
 public:
    decltype(pieces.begin()) lot(); //random piece from stack
    DS_stack();
-   Dominos::empty;
+   using Dominos::empty;
 };
 
 class DS_in_hand : public Dominos
@@ -60,7 +60,7 @@ friend class Move_real;
 public:
    Domino fit(); //domino with ends like ends of table(for checking, if human player could move)
    int fit(bool which_end);
-   Dominos::size;
+   using Dominos::size;
    friend std::ostream& operator<<(std::ostream& output, DS_table &input);
 };
 
@@ -154,6 +154,7 @@ class Player
 public:
    virtual void accept_pass(const std::string name) { }
    virtual Move_planned plan_move(Avatar *trigger, DS_in_hand *hand, Game *party) = 0;
+   virtual ~Player() {}
 };
 
 class Human : public Player


### PR DESCRIPTION
Indeed old depreciated method. You are supposed now to reference not-inherited-by-default methods of other (parent) class with 'using'. Also, you should have virtual destructors for abstract classes for the behavior to be defined.

No warnings on compilation now.